### PR TITLE
feat: add SelectBinaryExpr builder method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,10 @@ jobs:
       with:
         name: benchmark-results
         path: benchmark_results.txt
+
+  ci-complete:
+    name: CI Complete
+    needs: [test, lint, integration, security, benchmark]
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "CI complete"

--- a/docs/4.cookbook/2.vector-search.md
+++ b/docs/4.cookbook/2.vector-search.md
@@ -3,7 +3,7 @@ title: Vector Search
 description: pgvector similarity queries with ASTQL
 author: zoobzio
 published: 2025-12-13
-updated: 2025-12-13
+updated: 2026-01-21
 tags:
   - Cookbook
   - pgvector
@@ -90,7 +90,7 @@ err := db.Select(&docs, result.SQL, params)
 
 ## Selecting Distance as a Column
 
-Use `BinaryExpr` to include the computed distance in your results:
+Use `SelectBinaryExpr` to include the computed distance in your results:
 
 ```go
 func SearchWithDistance(instance *astql.ASTQL, limit int) (*astql.QueryResult, error) {
@@ -100,14 +100,12 @@ func SearchWithDistance(instance *astql.ASTQL, limit int) (*astql.QueryResult, e
             instance.F("title"),
             instance.F("content"),
         ).
-        SelectExpr(astql.As(
-            astql.BinaryExpr(
-                instance.F("embedding"),
-                astql.VectorL2Distance,
-                instance.P("query_embedding"),
-            ),
+        SelectBinaryExpr(
+            instance.F("embedding"),
+            astql.VectorL2Distance,
+            instance.P("query_embedding"),
             "distance",
-        )).
+        ).
         OrderByExpr(
             instance.F("embedding"),
             astql.VectorL2Distance,

--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -3,7 +3,7 @@ title: API Reference
 description: Complete API reference for the astql package
 author: zoobzio
 published: 2025-12-13
-updated: 2025-12-13
+updated: 2026-01-21
 tags:
   - Reference
   - API
@@ -375,6 +375,19 @@ func (b *Builder) SelectExpr(expr types.FieldExpression) *Builder
 
 Adds a field expression (aggregate, CASE, window function).
 
+### SelectBinaryExpr
+
+```go
+func (b *Builder) SelectBinaryExpr(f types.Field, op types.Operator, p types.Param, alias string) *Builder
+```
+
+Adds a binary expression (field <op> param) with an alias to SELECT. Useful for vector distance calculations with pgvector.
+
+```go
+// Returns: "embedding" <=> :query_vec AS "score"
+.SelectBinaryExpr(instance.F("embedding"), astql.VectorCosineDistance, instance.P("query_vec"), "score")
+```
+
 ### OnConflict
 
 ```go
@@ -523,13 +536,19 @@ func BinaryExpr(field types.Field, op types.Operator, param types.Param) types.F
 
 Creates a binary expression for `field <op> param` patterns. Commonly used with vector distance operators to select computed distances as columns.
 
+For selecting binary expressions, prefer the builder method `SelectBinaryExpr` for cleaner syntax:
+
 ```go
-// Select distance as a column
-astql.As(
+// Preferred: using SelectBinaryExpr
+.SelectBinaryExpr(instance.F("embedding"), astql.VectorL2Distance, instance.P("query"), "distance")
+
+// Alternative: using BinaryExpr with As
+.SelectExpr(astql.As(
     astql.BinaryExpr(instance.F("embedding"), astql.VectorL2Distance, instance.P("query")),
     "distance",
-)
-// "embedding" <-> :query AS "distance"
+))
+
+// Both render: "embedding" <-> :query AS "distance"
 ```
 
 ### Conditions


### PR DESCRIPTION
  Add convenience method for binary expressions in SELECT clause,
  mirroring the existing OrderByExpr pattern. Useful for pgvector
  distance calculations where the computed value needs to be returned.

  - Add SelectBinaryExpr(field, op, param, alias) to Builder
  - Add tests for basic usage, multiple expressions, and error cases
  - Update vector-search cookbook and API reference documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a convenience method to select computed expressions (e.g., vector distance) as aliased columns in SELECT queries.

* **Documentation**
  * Updated guides and API reference to show the new method and revised examples; updated timestamps.

* **Tests**
  * Added tests covering SQL generation, alias validation, multi-expression cases, and error scenarios.

* **Chores**
  * Added a final CI workflow job to mark pipeline completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->