### PR TITLE
feat: add SetExpr for expression-based UPDATE SET clauses (#10)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -145,6 +145,27 @@ func (b *Builder) Set(f types.Field, p types.Param) *Builder {
 	return b
 }
 
+// SetExpr adds a field update with an expression value for UPDATE queries.
+// Use this for computed assignments like `items_completed = items_completed + :increment`.
+func (b *Builder) SetExpr(f types.Field, expr types.FieldExpression) *Builder {
+	if b.err != nil {
+		return b
+	}
+	if b.ast.Operation != types.OpUpdate {
+		b.err = fmt.Errorf("SetExpr() can only be used with UPDATE queries")
+		return b
+	}
+	if expr.Alias != "" {
+		b.err = fmt.Errorf("SetExpr() does not support aliased expressions")
+		return b
+	}
+	if b.ast.UpdateExpressions == nil {
+		b.ast.UpdateExpressions = make(map[types.Field]types.FieldExpression)
+	}
+	b.ast.UpdateExpressions[f] = expr
+	return b
+}
+
 // Values adds a row of field-value pairs for INSERT queries.
 // Call Values() multiple times to insert multiple rows.
 // Use instance.ValueMap() to create the map programmatically.

--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -311,6 +311,25 @@ func (b *Builder) Set(f types.Field, p types.Param) *Builder
 
 Adds a field update. UPDATE only.
 
+### SetExpr
+
+```go
+func (b *Builder) SetExpr(f types.Field, expr types.FieldExpression) *Builder
+```
+
+Adds a field update with an expression value. UPDATE only. Use this for computed assignments like atomic increments.
+
+```go
+// Returns: "items_completed" = "items_completed" + :increment
+.SetExpr(instance.F("items_completed"), types.FieldExpression{
+    Binary: &types.BinaryExpression{
+        Field:    instance.F("items_completed"),
+        Operator: "+",
+        Param:    instance.P("increment"),
+    },
+})
+```
+
 ### Values
 
 ```go

--- a/mariadb/mariadb_test.go
+++ b/mariadb/mariadb_test.go
@@ -109,6 +109,119 @@ func TestRender_Update(t *testing.T) {
 	}
 }
 
+func TestRender_UpdateSetExpr(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "age"},
+					Operator: "+",
+					Param:    types.Param{Name: "increment"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	result, err := r.Render(ast)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	expected := "UPDATE `users` SET `age` = `age` + :increment WHERE `id` = :user_id"
+	if result.SQL != expected {
+		t.Errorf("SQL = %q, want %q", result.SQL, expected)
+	}
+}
+
+func TestRender_UpdateSetExpr_JSONB(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "data", JSONBTextKey: &types.Param{Name: "key"}}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "data"},
+					Operator: "+",
+					Param:    types.Param{Name: "val"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for JSONB field in UpdateExpressions")
+	}
+}
+
+func TestRender_UpdateSetExpr_ExprError(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Case: &types.CaseExpression{
+					WhenClauses: []types.WhenClause{
+						{Condition: nil, Result: types.Param{Name: "val"}},
+					},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for invalid expression in UpdateExpressions")
+	}
+}
+
+func TestRender_UpdateSetExpr_ExprJSONB(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "data", JSONBTextKey: &types.Param{Name: "key"}},
+					Operator: "+",
+					Param:    types.Param{Name: "val"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for JSONB in expression field")
+	}
+}
+
 func TestRender_Delete(t *testing.T) {
 	r := New()
 	ast := &types.AST{

--- a/mssql/mssql.go
+++ b/mssql/mssql.go
@@ -276,6 +276,16 @@ func (r *Renderer) validateAST(ast *types.AST) error {
 		}
 	}
 
+	for field := range ast.UpdateExpressions {
+		if err := r.checkJSONBField(field); err != nil {
+			return err
+		}
+		exprCopy := ast.UpdateExpressions[field]
+		if err := r.validateFieldExpression(&exprCopy); err != nil {
+			return err
+		}
+	}
+
 	for _, valueSet := range ast.Values {
 		for field := range valueSet {
 			if err := r.checkJSONBField(field); err != nil {
@@ -631,11 +641,30 @@ func (r *Renderer) renderUpdate(ast *types.AST, sql *strings.Builder, addParam f
 		return updateFields[i].Name < updateFields[j].Name
 	})
 
-	updates := make([]string, 0, len(ast.Updates))
+	updates := make([]string, 0, len(ast.Updates)+len(ast.UpdateExpressions))
 	for _, field := range updateFields {
 		param := ast.Updates[field]
 		updates = append(updates, fmt.Sprintf("%s = %s", r.quoteIdentifier(field.Name), addParam(param)))
 	}
+
+	// Render expression-based updates
+	exprFields := make([]types.Field, 0, len(ast.UpdateExpressions))
+	for field := range ast.UpdateExpressions {
+		exprFields = append(exprFields, field)
+	}
+	sort.Slice(exprFields, func(i, j int) bool {
+		return exprFields[i].Name < exprFields[j].Name
+	})
+	for _, field := range exprFields {
+		expr := ast.UpdateExpressions[field]
+		ctx := newRenderContext(addParam)
+		rendered, err := r.renderFieldExpression(expr, ctx)
+		if err != nil {
+			return err
+		}
+		updates = append(updates, fmt.Sprintf("%s = %s", r.quoteIdentifier(field.Name), rendered))
+	}
+
 	sql.WriteString(strings.Join(updates, ", "))
 
 	// OUTPUT clause for RETURNING

--- a/mssql/mssql_test.go
+++ b/mssql/mssql_test.go
@@ -134,6 +134,119 @@ func TestRender_Update(t *testing.T) {
 	}
 }
 
+func TestRender_UpdateSetExpr(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "age"},
+					Operator: "+",
+					Param:    types.Param{Name: "increment"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	result, err := r.Render(ast)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	expected := "UPDATE [users] SET [age] = [age] + :increment WHERE [id] = :user_id"
+	if result.SQL != expected {
+		t.Errorf("SQL = %q, want %q", result.SQL, expected)
+	}
+}
+
+func TestRender_UpdateSetExpr_JSONB(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "data", JSONBTextKey: &types.Param{Name: "key"}}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "data"},
+					Operator: "+",
+					Param:    types.Param{Name: "val"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for JSONB field in UpdateExpressions")
+	}
+}
+
+func TestRender_UpdateSetExpr_ExprError(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Case: &types.CaseExpression{
+					WhenClauses: []types.WhenClause{
+						{Condition: nil, Result: types.Param{Name: "val"}},
+					},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for invalid expression in UpdateExpressions")
+	}
+}
+
+func TestRender_UpdateSetExpr_ExprJSONB(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "data", JSONBTextKey: &types.Param{Name: "key"}},
+					Operator: "+",
+					Param:    types.Param{Name: "val"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for JSONB in expression field")
+	}
+}
+
 func TestRender_Delete(t *testing.T) {
 	r := New()
 	ast := &types.AST{

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -255,6 +255,16 @@ func (r *Renderer) validateAST(ast *types.AST) error {
 		}
 	}
 
+	for field := range ast.UpdateExpressions {
+		if err := r.checkJSONBField(field); err != nil {
+			return err
+		}
+		exprCopy := ast.UpdateExpressions[field]
+		if err := r.validateFieldExpression(&exprCopy); err != nil {
+			return err
+		}
+	}
+
 	for _, valueSet := range ast.Values {
 		for field := range valueSet {
 			if err := r.checkJSONBField(field); err != nil {
@@ -637,11 +647,30 @@ func (r *Renderer) renderUpdate(ast *types.AST, sql *strings.Builder, addParam f
 		return updateFields[i].Name < updateFields[j].Name
 	})
 
-	updates := make([]string, 0, len(ast.Updates))
+	updates := make([]string, 0, len(ast.Updates)+len(ast.UpdateExpressions))
 	for _, field := range updateFields {
 		param := ast.Updates[field]
 		updates = append(updates, fmt.Sprintf("%s = %s", r.quoteIdentifier(field.Name), addParam(param)))
 	}
+
+	// Render expression-based updates
+	exprFields := make([]types.Field, 0, len(ast.UpdateExpressions))
+	for field := range ast.UpdateExpressions {
+		exprFields = append(exprFields, field)
+	}
+	sort.Slice(exprFields, func(i, j int) bool {
+		return exprFields[i].Name < exprFields[j].Name
+	})
+	for _, field := range exprFields {
+		expr := ast.UpdateExpressions[field]
+		ctx := newRenderContext(addParam)
+		rendered, err := r.renderFieldExpression(expr, ctx)
+		if err != nil {
+			return err
+		}
+		updates = append(updates, fmt.Sprintf("%s = %s", r.quoteIdentifier(field.Name), rendered))
+	}
+
 	sql.WriteString(strings.Join(updates, ", "))
 
 	if ast.WhereClause != nil {

--- a/sqlite/sqlite_test.go
+++ b/sqlite/sqlite_test.go
@@ -108,6 +108,119 @@ func TestRender_Update(t *testing.T) {
 	}
 }
 
+func TestRender_UpdateSetExpr(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "age"},
+					Operator: "+",
+					Param:    types.Param{Name: "increment"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	result, err := r.Render(ast)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	expected := `UPDATE "users" SET "age" = "age" + :increment WHERE "id" = :user_id`
+	if result.SQL != expected {
+		t.Errorf("SQL = %q, want %q", result.SQL, expected)
+	}
+}
+
+func TestRender_UpdateSetExpr_JSONB(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "data", JSONBTextKey: &types.Param{Name: "key"}}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "data"},
+					Operator: "+",
+					Param:    types.Param{Name: "val"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for JSONB field in UpdateExpressions")
+	}
+}
+
+func TestRender_UpdateSetExpr_ExprError(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Case: &types.CaseExpression{
+					WhenClauses: []types.WhenClause{
+						{Condition: nil, Result: types.Param{Name: "val"}},
+					},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for invalid expression in UpdateExpressions")
+	}
+}
+
+func TestRender_UpdateSetExpr_ExprJSONB(t *testing.T) {
+	r := New()
+	ast := &types.AST{
+		Operation: types.OpUpdate,
+		Target:    types.Table{Name: "users"},
+		UpdateExpressions: map[types.Field]types.FieldExpression{
+			{Name: "age"}: {
+				Binary: &types.BinaryExpression{
+					Field:    types.Field{Name: "data", JSONBTextKey: &types.Param{Name: "key"}},
+					Operator: "+",
+					Param:    types.Param{Name: "val"},
+				},
+			},
+		},
+		WhereClause: types.Condition{
+			Field:    types.Field{Name: "id"},
+			Operator: types.EQ,
+			Value:    types.Param{Name: "user_id"},
+		},
+	}
+
+	_, err := r.Render(ast)
+	if err == nil {
+		t.Fatal("Expected error for JSONB in expression field")
+	}
+}
+
 func TestRender_Delete(t *testing.T) {
 	r := New()
 	ast := &types.AST{


### PR DESCRIPTION
  Support computed assignments in UPDATE queries (e.g. atomic
  increments) by adding a SetExpr builder method that accepts a
  FieldExpression for the right-hand side of SET clauses.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for computed/expression-based field updates in UPDATE statements (e.g., atomic increments).

* **Documentation**
  * Added API docs and examples demonstrating expression-based updates.

* **Bug Fixes / Validation**
  * Detects duplicate updates when mixing value- and expression-based assignments; improved validation and clear errors for invalid expressions and disallowed JSONB usage.

* **Tests**
  * Expanded tests covering rendering, error cases, and cross-database behavior for expression-based updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->